### PR TITLE
tracks weekend days when explicitly requested

### DIFF
--- a/lib/date_range.js
+++ b/lib/date_range.js
@@ -6,7 +6,22 @@ module.exports = function DateRange(startDate, endDate) {
     return this.startDate.isAfter(this.endDate)
   }
 
+  this.isAWeekend = function () {
+    const currentDate = startDate.clone()
+    while (currentDate.isSameOrBefore(endDate)) {
+      if (isWorkday(currentDate)) {
+        return false;
+      }
+      currentDate.add(1, 'days')
+    }
+    return true
+  }
+
   this.toItalianReadableString = function () {
     return "da " + startDate.locale('it').format('dddd DD MMMM') + " a " + endDate.locale('it').format('dddd DD MMMM')
   }
+}
+
+function isWorkday(day) {
+  return day.isoWeekday() < 6
 }

--- a/lib/track_helper.js
+++ b/lib/track_helper.js
@@ -25,7 +25,7 @@ function TrackHelper() {
       const currentDate = dateRange.startDate.clone()
       const skippedDates = []
       while (currentDate.isSameOrBefore(dateRange.endDate)) {
-        if (isNotWeekend(currentDate)) {
+        if (isAWorkday(currentDate) || dateRange.isAWeekend()) {
           promises.push(trackMorningAndAfternoon(currentDate.clone(), user.token, projectToTrack))
         } else {
           skippedDates.push(currentDate.clone())
@@ -56,7 +56,7 @@ function TrackHelper() {
     ])
   }
 
-  function isNotWeekend(day) {
+  function isAWorkday(day) {
     return day.isoWeekday() < 6
   }
 

--- a/test/offline/date_range_test.js
+++ b/test/offline/date_range_test.js
@@ -11,3 +11,19 @@ test('start date should be before end date', t => {
 
     t.is(true, range.isInvalid())
 })
+
+test('find when all the dates in a range are weekend days', t => {
+    const friday19 = moment('2018-10-19')
+    const saturday20 = moment('2018-10-20')
+    const sunday21 = moment('2018-10-21')
+    const monday22 = moment('2018-10-22')
+
+    let range = new DateRange(saturday20, sunday21)
+    t.is(true, range.isAWeekend())
+
+    range = new DateRange(saturday20, saturday20)
+    t.is(true, range.isAWeekend())
+
+    range = new DateRange(friday19, monday22)
+    t.is(false, range.isAWeekend())
+})

--- a/test/offline/dayinterval_command_test.js
+++ b/test/offline/dayinterval_command_test.js
@@ -67,6 +67,32 @@ test(`don't track weekends`, t => {
   })
 })
 
+test("tracks weekends when explicitly requested", t => {
+  const testableBotBuilder = new TestableBotBuilder()
+  const request = requestBuilder()
+    .withUsername(TESTUSER.username)
+    .withText('15-16')
+
+  const expectedEntries = [
+    entry('2016-10-15T09:00:00+02:00'),
+    entry('2016-10-15T14:00:00+02:00'),
+    entry('2016-10-16T09:00:00+02:00'),
+    entry('2016-10-16T14:00:00+02:00')
+  ]
+  const bot = testableBotBuilder
+    .withTodayDate(TODAY)
+    .withAlreadySavedUsers([TESTUSER])
+    .withExpectedCallsOnCreateTimeEntry(expectedEntries)
+    .build()
+
+  const response = bot(request)
+
+  return response.then(res => {
+    t.is('Ciao ' + TESTUSER.username + '. Ho tracciato le giornate da sabato 15 ottobre a domenica 16 ottobre sul progetto MPOS (9243852).', res)
+    testableBotBuilder.verifyMocksExpectations()
+  })
+})
+
 test('wrong ranges cannot be tracked', t => {
   const testableBotBuilder = new TestableBotBuilder()
   const request = requestBuilder()

--- a/test/offline/monthday_command_test.js
+++ b/test/offline/monthday_command_test.js
@@ -18,8 +18,8 @@ test('track past day in current month', t => {
   const request = requestBuilder()
     .withUsername(TESTUSER.username)
     .withText('18')
-  const expectedMorningEntry = entry(TESTUSER.project.id, TESTUSER.project.description, '2016-10-18T09:00:00+02:00')
-  const expectedAfternoonEntry = entry(TESTUSER.project.id, TESTUSER.project.description, '2016-10-18T14:00:00+02:00')
+  const expectedMorningEntry = entry('2016-10-18T09:00:00+02:00')
+  const expectedAfternoonEntry = entry('2016-10-18T14:00:00+02:00')
   const bot = testableBotBuilder
     .withTodayDate(TODAY)
     .withAlreadySavedUsers([TESTUSER])
@@ -34,13 +34,34 @@ test('track past day in current month', t => {
   })
 })
 
+test('tracks weekend day when explicitly requested', t => {
+  const testableBotBuilder = new TestableBotBuilder()
+  const request = requestBuilder()
+    .withUsername(TESTUSER.username)
+    .withText('16')
+  const expectedMorningEntry = entry('2016-10-16T09:00:00+02:00')
+  const expectedAfternoonEntry = entry('2016-10-16T14:00:00+02:00')
+  const bot = testableBotBuilder
+    .withTodayDate(TODAY)
+    .withAlreadySavedUsers([TESTUSER])
+    .withExpectedCallsOnCreateTimeEntry([expectedMorningEntry, expectedAfternoonEntry])
+    .build()
+
+  const response = bot(request)
+
+  return response.then(res => {
+    t.is('Ciao ' + TESTUSER.username + '. Ho tracciato la giornata di domenica 16 ottobre sul progetto MPOS (9243852).', res)
+    testableBotBuilder.verifyMocksExpectations()
+  })
+})
+
 test('it works also between months', t => {
   const testableBotBuilder = new TestableBotBuilder()
   const request = requestBuilder()
     .withUsername(TESTUSER.username)
     .withText('31')
-  const expectedMorningEntry = entry(TESTUSER.project.id, TESTUSER.project.description, '2016-10-31T09:00:00+01:00')
-  const expectedAfternoonEntry = entry(TESTUSER.project.id, TESTUSER.project.description, '2016-10-31T14:00:00+01:00')
+  const expectedMorningEntry = entry('2016-10-31T09:00:00+01:00')
+  const expectedAfternoonEntry = entry('2016-10-31T14:00:00+01:00')
   const bot = testableBotBuilder
     .withTodayDate('2016-11-02')
     .withAlreadySavedUsers([TESTUSER])
@@ -55,10 +76,10 @@ test('it works also between months', t => {
   })
 })
 
-function entry(pid, description, startTime) {
+function entry(startTime) {
   return {
-    pid: pid,
-    description: description,
+    pid: TESTUSER.project.id,
+    description: TESTUSER.project.description,
     created_with: 'TrackerBot',
     duration: 14400,
     billable: true,


### PR DESCRIPTION
Since #24 it was no longer possible to track weekends because it where skipped. With this PR it's possible to track them when you specify a range with ONLY weekends days or a specific day in the weekend.
E.g:
- Assume that the 20th of September is Saturday
`/t 20-21 ` will track Saturday and Sunday on the default project
`/t 20 ` will track Saturday on the default project